### PR TITLE
Add Dependabot configuration and GitHub Actions for auto-assigning issues and pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    target-branch: dev
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,19 @@
+name: Auto Assign
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - name: 'Auto-assign issue'
+      uses: pozil/auto-assign-issue@v2
+      with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: fakedude
+          numOfAssignee: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -77,6 +83,7 @@ jobs:
 
       - name: Attest
         uses: actions/attest-build-provenance@v1
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY . .
+COPY . /app
 RUN yarn install && yarn build
 EXPOSE 3636
 CMD [ "yarn", "preview" ,"--port", "3636" ]


### PR DESCRIPTION
This pull request introduces a Dependabot configuration for automatic updates of npm packages and GitHub Actions. It sets up an auto-assign feature for newly opened issues and pull requests, ensuring that a designated assignee is automatically assigned. Additionally, minor adjustments were made to the Dockerfile for clarity in the copy command. These enhancements aim to streamline dependency management and improve issue handling within the repository.