### PR TITLE
Update GitHub Actions workflow for Node.js 22 and Yarn

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,19 +29,19 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
           cache-dependency-path: './'
       - name: Install dependencies
-        run: npm install
+        run: yarn install
       - name: Build
-        run: npm run build
+        run: yarn build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './docs'
+          path: './dist'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+!dist/.gitkeep
 dist-ssr
 *.local
 


### PR DESCRIPTION
Upgrade the GitHub Actions workflow to use Node.js 22, switch from npm to Yarn for dependency management, and adjust the artifact path to './dist'. A .gitkeep file is also added to the dist directory.